### PR TITLE
Fix double encoding of $job_name

### DIFF
--- a/src/Api/Jobs.php
+++ b/src/Api/Jobs.php
@@ -151,7 +151,7 @@ class Jobs extends AbstractApi
     public function artifactsByRefName($project_id, string $ref_name, string $job_name)
     {
         return $this->getAsResponse('projects/'.self::encodePath($project_id).'/jobs/artifacts/'.self::encodePath($ref_name).'/download', [
-            'job' => self::encodePath($job_name),
+            'job' => $job_name,
         ])->getBody();
     }
 
@@ -166,7 +166,7 @@ class Jobs extends AbstractApi
     public function artifactByRefName($project_id, string $ref_name, string $job_name, string $artifact_path)
     {
         return $this->getAsResponse('projects/'.self::encodePath($project_id).'/jobs/artifacts/'.self::encodePath($ref_name).'/raw/'.self::encodePath($artifact_path), [
-            'job' => self::encodePath($job_name),
+            'job' => $job_name,
         ])->getBody();
     }
 

--- a/tests/Api/JobsTest.php
+++ b/tests/Api/JobsTest.php
@@ -171,12 +171,12 @@ class JobsTest extends TestCase
         $api->expects($this->once())
             ->method('getAsResponse')
             ->with('projects/1/jobs/artifacts/master/download', [
-                'job' => 'job_name',
+                'job' => 'job name',
             ])
             ->will($this->returnValue($returnedStream))
         ;
 
-        $this->assertEquals('foobar', $api->artifactsByRefName(1, 'master', 'job_name')->getContents());
+        $this->assertEquals('foobar', $api->artifactsByRefName(1, 'master', 'job name')->getContents());
     }
 
     /**
@@ -189,11 +189,11 @@ class JobsTest extends TestCase
         $api->expects($this->once())
             ->method('getAsResponse')
             ->with('projects/1/jobs/artifacts/master/raw/artifact_path', [
-                'job' => 'job_name',
+                'job' => 'job name',
             ])
             ->will($this->returnValue($returnedStream))
         ;
-        $this->assertEquals('foobar', $api->artifactByRefName(1, 'master', 'job_name', 'artifact_path')->getContents());
+        $this->assertEquals('foobar', $api->artifactByRefName(1, 'master', 'job name', 'artifact_path')->getContents());
     }
 
     /**


### PR DESCRIPTION
Removed call to self::encodePath, as the `job` parameter is part of a url query, which is later encoded by `QueryStringBuilder` in `AbstractApi::prepareUri`


I have not checked other methods for this bug, but it might be there. 


Background:

Gitlab-ci allows spaces in Job names. Bug in Gitlab\Client double encodes the job names, so spaces are mapped to %2520 instead of %20, and Gitlab returns 404 not found instead of job artifacts. 

To reproduce the bug create a job with space in name

example gitlab-ci.yml:
```
extract translations:
    artifacts:
        name: translations
        paths: 
            - locale
    script:
        - do something    
```

Download artifacts:

```php
$client = new \Gitlab\Client();
$gitlabStream = $client->jobs()->artifactsByRefName($project, $branch, 'extract translations' );
```
Result -  404 Not Found. 
